### PR TITLE
Change NetworkImage to CachedNetworkImageProvider

### DIFF
--- a/lib/photo_opener.dart
+++ b/lib/photo_opener.dart
@@ -177,7 +177,7 @@ onOpenPhoto({
                             scaleStateController: photoController,
                             imageProvider: !isNetwork
                                 ? AssetImage(images[index])
-                                : NetworkImage(images[index]),
+                                : CachedNetworkImageProvider(images[index]),
                             maxScale: PhotoViewComputedScale.contained *
                                 (maxScale ?? 5),
                             initialScale: PhotoViewComputedScale.contained * 1,


### PR DESCRIPTION
With this, the images will not be re-downloaded from the network